### PR TITLE
Fix MODS XML output (resolve #34)

### DIFF
--- a/lib/detail.inc.php
+++ b/lib/detail.inc.php
@@ -259,12 +259,10 @@ class detail extends content_list
 
         // parse title
         $_title_sub = '';
-        $_title_statement_resp = '';
+        $_title_statement_resp = trim($this->record_detail['sor']);
         if (stripos($this->record_detail['title'], ':') !== false) {
             $_title_main = trim(substr_replace($this->record_detail['title'], '', stripos($this->record_detail['title'], ':')+1));
             $_title_sub = trim(substr_replace($this->record_detail['title'], '', 0, stripos($this->record_detail['title'], ':')+1));
-        } else if (stripos($this->record_detail['title'], '/') !== false) {
-            $_title_statement_resp = trim(substr_replace($this->record_detail['title'], '', stripos($this->record_detail['title'], '/')+1));
         } else {
             $_title_main = trim($this->record_detail['title']);
         }


### PR DESCRIPTION
Sesuai laporan [Ido Alit](https://www.facebook.com/groups/84601011963/10152422395191964), menggunakan tanda `/` di dalam kolom judul menyebabkan error di output MODS XML. Menyesuaikan dengan struktur database yang ada, `$_title_statement_resp` menggunakan record value `sor`. Deteksi _statement of responsibility_ di kolom judul saya hapus, karena sudah tidak diperlukan lagi.
